### PR TITLE
Captured response body for `HTTP` and `HTTP2` integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Check out [this part](https://thundra.readme.io/docs/how-to-warmup) in our docs 
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_AWS_DYNAMODB_TRACEINJECTION_ENABLE |  bool  |              false              |
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_AWS_ATHENA_STATEMENT_MASK          |  bool  |              false              |
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_BODY_MASK                     |  bool  |              false              |
+| THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_RESPONSE_BODY_MASK            |  bool  |              false              |
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_URL_DEPTH                     | number |                1                |
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_TRACEINJECTION_DISABLE        |  bool  |              false              |
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_ERROR_ON4XX_DISABLE           |  bool  |              false              |

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -415,6 +415,7 @@ export const HttpTags = {
     HTTP_ROUTE_PATH: 'http.route_path',
     QUERY_PARAMS: 'http.query_params',
     BODY: 'http.body',
+    RESPONSE_BODY: 'http.response.body',
 };
 
 export const RedisTags = {
@@ -529,6 +530,13 @@ export const SpanTags = {
     TOPOLOGY_VERTEX: 'topology.vertex',
     TRACE_LINKS: 'trace.links',
     RESOURCE_NAMES: 'resource.names',
+};
+
+export const ErrorTags = {
+    ERROR: 'error',
+    ERROR_KIND: 'error.kind',
+    ERROR_MESSAGE: 'error.message',
+    ERROR_STACK: 'error.stack',
 };
 
 export const TraceHeaderTags = {
@@ -777,6 +785,7 @@ export const SPAN_TAGS_TO_TRIM_2: string[] = [
     AwsLambdaWrapperTags.AWS_LAMBDA_INVOCATION_REQUEST,
     AwsLambdaWrapperTags.AWS_LAMBDA_INVOCATION_RESPONSE,
     HttpTags.BODY,
+    HttpTags.RESPONSE_BODY,
     DBTags.DB_STATEMENT,
     RedisTags.REDIS_COMMAND,
     RedisTags.REDIS_COMMANDS,
@@ -805,7 +814,8 @@ export const TESTCONTAINERS_HTTP_PATH_PATTERNS: any = {
     PATTERN4: /images\/\w*/,
 };
 
-export const MAX_HTTP_VALUE_SIZE: number = 10 * 1024;
+export const MAX_HTTP_REQUEST_SIZE: number = 10 * 1024; // 10 KB
+export const MAX_HTTP_RESPONSE_SIZE: number = 10 * 1024; // 10 KB
 
 export const REPORTER_HTTP_TIMEOUT: number = 3000;
 

--- a/src/config/ConfigMetadata.ts
+++ b/src/config/ConfigMetadata.ts
@@ -189,6 +189,10 @@ export const ConfigMetadata: {[key: string]: { type: string, defaultValue?: any 
         type: 'boolean',
         defaultValue: false,
     },
+    [ConfigNames.THUNDRA_TRACE_INTEGRATIONS_HTTP_RESPONSE_BODY_MASK]: {
+        type: 'boolean',
+        defaultValue: false,
+    },
     [ConfigNames.THUNDRA_TRACE_INTEGRATIONS_HTTP_URL_DEPTH]: {
         type: 'number',
         defaultValue: 1,

--- a/src/config/ConfigNames.ts
+++ b/src/config/ConfigNames.ts
@@ -140,6 +140,8 @@ class ConfigNames {
 
     public static readonly THUNDRA_TRACE_INTEGRATIONS_HTTP_BODY_MASK: string =
         'thundra.agent.trace.integrations.http.body.mask';
+    public static readonly THUNDRA_TRACE_INTEGRATIONS_HTTP_RESPONSE_BODY_MASK: string =
+        'thundra.agent.trace.integrations.http.response.body.mask';
     public static readonly THUNDRA_TRACE_INTEGRATIONS_HTTP_URL_DEPTH: string =
         'thundra.agent.trace.integrations.http.url.depth';
     public static readonly THUNDRA_TRACE_INTEGRATIONS_HTTP_TRACEINJECTION_DISABLE: string =

--- a/src/plugins/config/TraceConfig.ts
+++ b/src/plugins/config/TraceConfig.ts
@@ -49,6 +49,7 @@ class TraceConfig extends BasePluginConfig {
     maskLambdaPayload: boolean;
     maskEventBridgeDetail: boolean;
     maskHttpBody: boolean;
+    maskHttpResponseBody: boolean;
     sampler: Sampler<any>;
     runSamplerOnEachSpan: boolean;
     instrumentAWSOnLoad: boolean;
@@ -108,6 +109,9 @@ class TraceConfig extends BasePluginConfig {
         this.maskHttpBody = ConfigProvider.get<boolean>(
             ConfigNames.THUNDRA_TRACE_INTEGRATIONS_HTTP_BODY_MASK,
             options.maskHttpBody);
+        this.maskHttpResponseBody = ConfigProvider.get<boolean>(
+            ConfigNames.THUNDRA_TRACE_INTEGRATIONS_HTTP_RESPONSE_BODY_MASK,
+            options.maskHttpResponseBody);
         this.maskEventBridgeDetail = ConfigProvider.get<boolean>(
             ConfigNames.THUNDRA_TRACE_INTEGRATIONS_EVENTBRIDGE_DETAIL_MASK,
             options.maskEventBridgeDetail);

--- a/test/integrations/http.integration.test.js
+++ b/test/integrations/http.integration.test.js
@@ -5,6 +5,7 @@ import ExecutionContextManager from '../../dist/context/ExecutionContextManager'
 import ExecutionContext from '../../dist/context/ExecutionContext';
 
 import HTTPUtils from '../../dist/utils/HTTPUtils';
+import {HttpTags, SpanTags, ErrorTags} from '../../dist/Constants';
 
 describe('HTTP integration', () => {
     let tracer;
@@ -33,15 +34,19 @@ describe('HTTP integration', () => {
         expect(span.className).toBe('HTTP');
         expect(span.domainName).toBe('API');
 
-        expect(span.tags['operation.type']).toBe('GET');
-        expect(span.tags['http.method']).toBe('GET');
-        expect(span.tags['http.host']).toBe('httpstat.us');
-        expect(span.tags['http.path']).toBe('/200');
-        expect(span.tags['http.url']).toBe('httpstat.us/200?userId=1');
-        expect(span.tags['http.query_params']).toBe('userId=1');
-        expect(span.tags['http.status_code']).toBe(200);
-        expect(span.tags['topology.vertex']).toEqual(true);
-        expect(span.tags['http.body']).not.toBeTruthy();
+        expect(span.tags[SpanTags.OPERATION_TYPE]).toBe('GET');
+        expect(span.tags[HttpTags.HTTP_METHOD]).toBe('GET');
+        expect(span.tags[HttpTags.HTTP_HOST]).toBe('httpstat.us');
+        expect(span.tags[HttpTags.HTTP_PATH]).toBe('/200');
+        expect(span.tags[HttpTags.HTTP_URL]).toBe('httpstat.us/200?userId=1');
+        expect(span.tags[HttpTags.QUERY_PARAMS]).toBe('userId=1');
+        expect(span.tags[HttpTags.HTTP_STATUS]).toBe(200);
+        expect(span.tags[ErrorTags.ERROR]).toBe(undefined);
+        expect(span.tags[ErrorTags.ERROR_KIND]).toBe(undefined);
+        expect(span.tags[ErrorTags.ERROR_MESSAGE]).toBe(undefined);
+        expect(span.tags[SpanTags.TOPOLOGY_VERTEX]).toEqual(true);
+        expect(span.tags[HttpTags.BODY]).not.toBeTruthy();
+        expect(span.tags[HttpTags.RESPONSE_BODY]).not.toBeTruthy();
     });
 
     test('should set 4XX 5XX errors on HTTP calls', async () => {
@@ -56,17 +61,18 @@ describe('HTTP integration', () => {
         expect(span.className).toBe('HTTP');
         expect(span.domainName).toBe('API');
 
-        expect(span.tags['operation.type']).toBe('GET');
-        expect(span.tags['http.method']).toBe('GET');
-        expect(span.tags['http.host']).toBe('httpstat.us');
-        expect(span.tags['http.path']).toBe('/404');
-        expect(span.tags['http.url']).toBe('httpstat.us/404');
-        expect(span.tags['http.status_code']).toBe(404);
-        expect(span.tags['error']).toBe(true);
-        expect(span.tags['error.kind']).toBe('HttpError');
-        expect(span.tags['error.message']).toBe('Not Found');
-        expect(span.tags['topology.vertex']).toEqual(true);
-        expect(span.tags['http.body']).not.toBeTruthy();
+        expect(span.tags[SpanTags.OPERATION_TYPE]).toBe('GET');
+        expect(span.tags[HttpTags.HTTP_METHOD]).toBe('GET');
+        expect(span.tags[HttpTags.HTTP_HOST]).toBe('httpstat.us');
+        expect(span.tags[HttpTags.HTTP_PATH]).toBe('/404');
+        expect(span.tags[HttpTags.HTTP_URL]).toBe('httpstat.us/404');
+        expect(span.tags[HttpTags.HTTP_STATUS]).toBe(404);
+        expect(span.tags[ErrorTags.ERROR]).toBe(true);
+        expect(span.tags[ErrorTags.ERROR_KIND]).toBe('HttpError');
+        expect(span.tags[ErrorTags.ERROR_MESSAGE]).toBe('Not Found');
+        expect(span.tags[SpanTags.TOPOLOGY_VERTEX]).toEqual(true);
+        expect(span.tags[HttpTags.BODY]).not.toBeTruthy();
+        expect(span.tags[HttpTags.RESPONSE_BODY]).not.toBeTruthy();
     });
 
     test('should disable 4XX 5XX errors on HTTP calls', async () => {
@@ -81,17 +87,18 @@ describe('HTTP integration', () => {
         expect(span.className).toBe('HTTP');
         expect(span.domainName).toBe('API');
 
-        expect(span.tags['operation.type']).toBe('GET');
-        expect(span.tags['http.method']).toBe('GET');
-        expect(span.tags['http.host']).toBe('httpstat.us');
-        expect(span.tags['http.path']).toBe('/404');
-        expect(span.tags['http.url']).toBe('httpstat.us/404');
-        expect(span.tags['http.status_code']).toBe(404);
-        expect(span.tags['error']).toBe(undefined);
-        expect(span.tags['error.kind']).toBe(undefined);
-        expect(span.tags['error.message']).toBe(undefined);
-        expect(span.tags['topology.vertex']).toEqual(true);
-        expect(span.tags['http.body']).not.toBeTruthy();
+        expect(span.tags[SpanTags.OPERATION_TYPE]).toBe('GET');
+        expect(span.tags[HttpTags.HTTP_METHOD]).toBe('GET');
+        expect(span.tags[HttpTags.HTTP_HOST]).toBe('httpstat.us');
+        expect(span.tags[HttpTags.HTTP_PATH]).toBe('/404');
+        expect(span.tags[HttpTags.HTTP_URL]).toBe('httpstat.us/404');
+        expect(span.tags[HttpTags.HTTP_STATUS]).toBe(404);
+        expect(span.tags[ErrorTags.ERROR]).toBe(undefined);
+        expect(span.tags[ErrorTags.ERROR_KIND]).toBe(undefined);
+        expect(span.tags[ErrorTags.ERROR_MESSAGE]).toBe(undefined);
+        expect(span.tags[SpanTags.TOPOLOGY_VERTEX]).toEqual(true);
+        expect(span.tags[HttpTags.BODY]).not.toBeTruthy();
+        expect(span.tags[HttpTags.RESPONSE_BODY]).not.toBeTruthy();
     });
 
     test('should instrument HTTPS POST calls', async () => {
@@ -107,8 +114,9 @@ describe('HTTP integration', () => {
         expect(span.className).toBe('HTTP');
         expect(span.domainName).toBe('API');
 
-        expect(span.tags['http.method']).toBe('POST');
-        expect(span.tags['http.body']).toBe('{"todo":"Buy the milk"}');
+        expect(span.tags[HttpTags.HTTP_METHOD]).toBe('POST');
+        expect(span.tags[HttpTags.BODY]).toBe('{"todo":"Buy the milk"}');
+        expect(span.tags[HttpTags.RESPONSE_BODY]).not.toBeTruthy();
     });
 
     test('should mask body in post', async () => {
@@ -124,8 +132,9 @@ describe('HTTP integration', () => {
         expect(span.className).toBe('HTTP');
         expect(span.domainName).toBe('API');
 
-        expect(span.tags['http.method']).toBe('POST');
-        expect(span.tags['http.body']).not.toBeTruthy();
+        expect(span.tags[HttpTags.HTTP_METHOD]).toBe('POST');
+        expect(span.tags[HttpTags.BODY]).not.toBeTruthy();
+        expect(span.tags[HttpTags.RESPONSE_BODY]).not.toBeTruthy();
     });
 
     test('should instrument api gateway calls ', () => {

--- a/test/integrations/utils/http.integration.utils.js
+++ b/test/integrations/utils/http.integration.utils.js
@@ -60,7 +60,7 @@ module.exports.post = (https) => {
 
         const options = {
             hostname: 'flaviocopes.com',
-            port: 443,
+            port: 80,
             path: '/todos',
             method: 'POST',
             headers: {

--- a/test/mock-server/route/index.js
+++ b/test/mock-server/route/index.js
@@ -13,7 +13,7 @@ module.exports = {
         });
         
         stream.end(JSON.stringify({
-            testField: 'test-value'
+            testField: 'test-response'
         }));
     },
     '/404': (stream) => {


### PR DESCRIPTION
… (enabled by default but it can be disabled)