### PR TITLE
Disable instrumenting http response body by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Check out [this part](https://thundra.readme.io/docs/how-to-warmup) in our docs 
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_AWS_DYNAMODB_TRACEINJECTION_ENABLE |  bool  |              false              |
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_AWS_ATHENA_STATEMENT_MASK          |  bool  |              false              |
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_BODY_MASK                     |  bool  |              false              |
-| THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_RESPONSE_BODY_MASK            |  bool  |              false              |
+| THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_RESPONSE_BODY_MASK            |  bool  |              true               |
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_URL_DEPTH                     | number |                1                |
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_TRACEINJECTION_DISABLE        |  bool  |              false              |
 | THUNDRA_AGENT_TRACE_INTEGRATIONS_HTTP_ERROR_ON4XX_DISABLE           |  bool  |              false              |

--- a/src/config/ConfigMetadata.ts
+++ b/src/config/ConfigMetadata.ts
@@ -205,7 +205,7 @@ export const ConfigMetadata: {[key: string]: { type: string, defaultValue?: any 
     },
     [ConfigNames.THUNDRA_TRACE_INTEGRATIONS_HTTP_RESPONSE_BODY_MASK]: {
         type: 'boolean',
-        defaultValue: false,
+        defaultValue: true,
     },
     [ConfigNames.THUNDRA_TRACE_INTEGRATIONS_HTTP_URL_DEPTH]: {
         type: 'number',

--- a/src/integrations/HttpIntegration.ts
+++ b/src/integrations/HttpIntegration.ts
@@ -210,7 +210,7 @@ class HttpIntegration implements Integration {
                             let chunks: Buffer[] = [];
                             let totalSize: Number = 0;
 
-                            res.on('data', (chunk: any) => {
+                            res.prependListener('data', (chunk: any) => {
                                 if (!chunk) {
                                     return;
                                 }


### PR DESCRIPTION
Disable instrumenting http response body by default & use 'prependListener' for subscribe data event of http response object